### PR TITLE
feat: add home social links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,9 @@ minimal_ryan:
   home:
     image:
       src: /assets/images/me.jpg
+    links:
+      - { title: LinkedIn, icon: linkedin, link: https://www.linkedin.com/in/ryansheppardd/ }
+      - { title: X, icon: x, link: https://x.com/sheppsryan }
   footer:
     contact:
       - { title: Email, link: mailto:sheppardryan@rogers.com }


### PR DESCRIPTION
## Summary
- Add LinkedIn and X home-page social link configuration
- Uses the home social icon support from ryanshepps/jekyll-theme-minimal-ryan#6